### PR TITLE
Delete ':' in Start Date

### DIFF
--- a/app/views/admin/programs/show.html.haml
+++ b/app/views/admin/programs/show.html.haml
@@ -8,7 +8,7 @@
       %dl.dl-horizontal
         - if @cfp
           %dt
-            Start Date:
+            Start Date
           %dd#start_date
             = @cfp.start_date.strftime('%A, %B %-d. %Y')
           %dt


### PR DESCRIPTION
I have changed the 'Start Date:' to 'Start Date'. It looks better that way.