### PR TITLE
Delete ':' from cfps events_cfp view

### DIFF
--- a/app/views/admin/cfps/_events_cfp.html.haml
+++ b/app/views/admin/cfps/_events_cfp.html.haml
@@ -19,7 +19,7 @@
 %dd
   = event_types(@conference)
 %dt
-  Tracks:
+  Tracks
 %dd
   = tracks(@conference)
 %dt


### PR DESCRIPTION
## Change 'Call for Papers' (_events_cfp.html.haml) View

- Remove ':' from 'Tracks', line 22, at app/views/admin/cfps/_events_cfp.html.haml